### PR TITLE
Updated to support secret encoded as Base64

### DIFF
--- a/box.json
+++ b/box.json
@@ -6,7 +6,7 @@
     "type":"modules",
     "location":"andrew-dixon/cb-jwt#v1.0.3",
     "devDependencies":{
-        "testbox":"2.3.0+00044"
+        "testbox":"2.8.0+191"
     },
     "installPaths":{
         "testbox":"testbox"

--- a/models/JWTService.cfc
+++ b/models/JWTService.cfc
@@ -1,7 +1,7 @@
 component singleton {
-	
-	/* 
-		Available algorithms: 
+
+	/*
+		Available algorithms:
 
 			* HmacSHA256
 			* HmacSHA384
@@ -14,8 +14,14 @@ component singleton {
 		"HS512": "HmacSHA512"
 	};
 
-	function decode( required string token, required string key , string algorithm = "HS512" ) {
-	
+	/**
+	* @token A valid JWT, having three segments separated by dots
+	* @key The secret used to verify the signature which may be a string of characters or a collection of bytes expressed in Base64
+	* @algorithm One of three supported algorithms: HS256, HS384, HS512
+	* @secretIsBase64 When true, the secret is the collection of bytes represented in Base64, not the literal characters passed as @key
+	*/
+	function decode( required string token, required string key, string algorithm="HS512", boolean secretIsBase64=false ) {
+
 		if ( ListLen( arguments.token , "." ) != 3 ) {
 			throw( type="Invalid Token", message="Token should contain 3 segments" );
 		}
@@ -25,28 +31,40 @@ component singleton {
 		var signiture 	= ListGetAt( arguments.token , 3 , "." );
 
 		var signInput = ListGetAt( arguments.token , 1 , "." ) & "." & ListGetAt( arguments.token , 2 , "." );
-		if ( signiture != _sign( signInput , arguments.key , arguments.algorithm )) {
+		if ( signiture != _sign( signInput, arguments.key, arguments.algorithm, arguments.secretIsBase64 )) {
 			throw( type="Invalid Token" , message="Signiture verification failed");
 		}
 
 		return payload;
 	}
 
-	function encode( required struct payload , required string key , string algorithm="HS512" ) {
+	/**
+	* @payload A CFML structure to be serialized as the token payload
+	* @key The secret used to sign the JWT, which may be a string of characters or a collection of bytes expressed in Base64
+	* @algorithm One of three supported algorithms: HS256, HS384, HS512
+	* @secretIsBase64 When true, the secret is the collection of bytes represented in Base64, not the literal characters passed as @key
+	*/
+	function encode( required struct payload, required string key, string algorithm="HS512", boolean secretIsBase64=false ) {
 
 		var segments = "";
 
 		segments = ListAppend( segments , _base64UrlEscape( toBase64( serializeJSON( { "typ" =  "JWT", "alg" = arguments.algorithm } ))) , "." );
 		segments = ListAppend( segments , _base64UrlEscape( toBase64( serializeJSON( arguments.payload ))) , "." );
-		segments = ListAppend( segments , _sign( segments , arguments.key , arguments.algorithm ) , "." );
+		segments = ListAppend( segments , _sign( segments, arguments.key, arguments.algorithm, arguments.secretIsBase64 ) , "." );
 
 		return segments;
 	}
 
-	function verify( required string token, required string key , string algorithm="HS512" ) {
+	/**
+	* @token A valid JWT, having three segments separated by dots
+	* @key The secret used to sign the JWT, which may be a string of characters or a collection of bytes expressed in Base64
+	* @algorithm One of three supported algorithms: HS256, HS384, HS512
+	* @secretIsBase64 When true, the secret is the collection of bytes represented in Base64, not the literal characters passed as @key
+	*/
+	function verify( required string token, required string key, string algorithm="HS512", boolean secretIsBase64=false ) {
 		var isValid = true;
 		try {
-			decode( arguments.token, arguments.key , arguments.algorithm );
+			decode( arguments.token, arguments.key, arguments.algorithm, arguments.secretIsBase64 );
 		}
 		catch(any e) {
 			isValid = false;
@@ -55,8 +73,8 @@ component singleton {
 		return isValid;
 	}
 
-	private function _sign( required string msg , required string key , string algorithm="HS512" ) {
-		var keySpec = CreateObject( "java" , "javax.crypto.spec.SecretKeySpec" ).init( arguments.key.getBytes() , arguments.algorithm );
+	private function _sign( required string msg, required string key, string algorithm="HS512", boolean secretIsBase64=false ) {
+		var keySpec = CreateObject( "java" , "javax.crypto.spec.SecretKeySpec" ).init( arguments.secretIsBase64 ? binaryDecode(_base64UrlUnescape(arguments.key), "base64") : arguments.key.getBytes(), arguments.algorithm );
 		var mac = CreateObject( "java" , "javax.crypto.Mac" ).getInstance( variables.instance.algorithmMap[arguments.algorithm] );
 		mac.init( keySpec );
 		return _base64URLEscape( toBase64( mac.doFinal( msg.getBytes() )));

--- a/tests/specs/integration/models/JWTService.cfc
+++ b/tests/specs/integration/models/JWTService.cfc
@@ -1,29 +1,35 @@
 component extends="testbox.system.BaseSpec" {
-	
+
 	/*********************************** LIFE CYCLE Methods ***********************************/
 
 	function beforeAll() {
 
 		jwt = new models.JWTService();
 
-		payload = { 
+		payload = {
 					'ts' = '2016-07-01 12:30:00',
 					'userid' = 'jdoe',
 					'anythingIlike' = 'somevalue'
 				};
 
 		key = 'my-secret-key';
+		keyAsBase64 = 'Zm9vLWJhci1ib28tYmF6LXNlY3JldA';
 
 		JWTs = {
-			'HmacSHA256' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIbWFjU0hBMjU2In0.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9.lKWBhDp82eKHsT6U59B45jZel8UlIyhOpeXjy77NaVg',
-			'HmacSHA384' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIbWFjU0hBMzg0In0.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9.nP68Cgs8xRlIPHcCHMXhuB4RTdT8Mz7ci_RE_11tNb_y4nGTLcwuHaB_Rq4T9eQr',
-			'HmacSHA512' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIbWFjU0hBNTEyIn0.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9.TUKr6u5Ud803kgogt_aSiaZRCVX7EKdHyXXej1hbj4f4IsiIIiGGDKB170BVMRZuSv83r85n-6NmPh3VEVXNQg'
-		}
+			'HS256' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9.7j1hXffzImfU9ahv-JeTf35zc6Us3r-2IIBVb_tYpMs',
+			'HS384' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9.GoQQ2pLda1GzqODp8oaVQmMyhVbBBsgP9hEqErqRzFH0pq2nHwKn4ViK5LIo2W26',
+			'HS512' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9.sbeVB6v73IPtd8YhUL3b1I3kYYP9gIUYgrTSs6P2YcNH95LJVTN0ihfvyQDm329WP1CjHNyGtSVVIDfHPWW2YA'
+		};
+		JWTsUsingSecretInBase64 = {
+			'HS256' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9._iMCD0BjJjUwTm-9ViaOGiJ3WT9Sww2Cn30_vRrZYJE',
+			'HS384' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9.k9IcOykSN9bzeJGzfM7b3Cqk6cpoJ89volAcSOxq_AfNYUaprdomhaElKpVeepvc',
+			'HS512' = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJ1c2VyaWQiOiJqZG9lIiwiYW55dGhpbmdJbGlrZSI6InNvbWV2YWx1ZSIsInRzIjoiMjAxNi0wNy0wMSAxMjozMDowMCJ9.TPNFA59ToYTCABKcx6J23bLgm9NHjKJhlOCdt0mQXSIPqwvsV-c5t6MD3pOyK76ICvWRKGDKXQ-UhL_-Q6eUOg'
+		};
 
 	}
 
 	/*********************************** BDD SUITES ***********************************/
-	
+
 	function run() {
 
 		describe( "JSON Web Token Tests", function() {
@@ -33,11 +39,13 @@ component extends="testbox.system.BaseSpec" {
 					then( "a JSON Web Token should be returned", function() {
 
 						loop struct=JWTs item="algorithm" {
-							
 							actual = jwt.encode( payload , key , algorithm );
-
 							expect( actual ).toBe( JWTs[algorithm] );
-						
+						}
+
+						loop struct=JWTsUsingSecretInBase64 item="algorithm" {
+							actual = jwt.encode( payload, keyAsBase64, algorithm, true );
+							expect( actual ).toBe( JWTsUsingSecretInBase64[algorithm] );
 						}
 
 					});
@@ -49,11 +57,10 @@ component extends="testbox.system.BaseSpec" {
 					then( "a payload structure should be returned", function() {
 
 						loop struct=JWTs item="algorithm" {
-
 							actual = jwt.decode( JWTs[algorithm] , key , algorithm );
-							
+
 							expect( actual ).toBeTypeOf( 'struct' );
-							
+
 							expect( actual ).toHaveKey( 'ts' );
 							expect( actual ).toHaveKey( 'userid' );
 							expect( actual ).toHaveKey( 'anythingIlike' );
@@ -61,24 +68,44 @@ component extends="testbox.system.BaseSpec" {
 							expect( actual.ts ).toBe( payload.ts );
 							expect( actual.userid ).toBe( payload.userid );
 							expect( actual.anythingIlike ).toBe( payload.anythingIlike );
-						
 						}
+
+						loop struct=JWTsUsingSecretInBase64 item="algorithm" {
+							actual = jwt.decode( JWTsUsingSecretInBase64[algorithm], keyAsBase64, algorithm, true );
+
+							expect( actual ).toBeTypeOf( 'struct' );
+
+							expect( actual ).toHaveKey( 'ts' );
+							expect( actual ).toHaveKey( 'userid' );
+							expect( actual ).toHaveKey( 'anythingIlike' );
+
+							expect( actual.ts ).toBe( payload.ts );
+							expect( actual.userid ).toBe( payload.userid );
+							expect( actual.anythingIlike ).toBe( payload.anythingIlike );
+						}
+
 					});
 				});
 			});
-		
+
 			story( "I need to be able to verify a JSON Web Token", function() {
 				given( "a valid token", function() {
 					then( "a true boolean should be returned", function() {
 
 						loop struct=JWTs item="algorithm" {
-
 							actual = jwt.verify( JWTs[algorithm] , key , algorithm );
-							
+
 							expect( actual ).toBeTypeOf( 'boolean' );
 							expect( actual ).toBe( true );
-						
 						}
+
+						loop struct=JWTsUsingSecretInBase64 item="algorithm" {
+							actual = jwt.verify( JWTsUsingSecretInBase64[algorithm], keyAsBase64, algorithm, true );
+
+							expect( actual ).toBeTypeOf( 'boolean' );
+							expect( actual ).toBe( true );
+						}
+
 					});
 				});
 
@@ -86,12 +113,17 @@ component extends="testbox.system.BaseSpec" {
 					then( "a false boolean should be returned", function() {
 
 						loop struct=JWTs item="algorithm" {
-
 							actual = jwt.verify( JWTs[algorithm] & "make-token-invalid" , key , algorithm );
-							
+
 							expect( actual ).toBeTypeOf( 'boolean' );
 							expect( actual ).toBe( false );
-						
+						}
+
+						loop struct=JWTsUsingSecretInBase64 item="algorithm" {
+							actual = jwt.verify( JWTsUsingSecretInBase64[algorithm] & "make-token-invalid", keyAsBase64, algorithm, true );
+
+							expect( actual ).toBeTypeOf( 'boolean' );
+							expect( actual ).toBe( false );
 						}
 					});
 				});


### PR DESCRIPTION
A new optional argument is added to JWTService's encode(), decode(), and sign() methods to specify that the secret is encoded as Base64. This works well when using an identity solution like Auth0 which provide the secret as a Base64 encoded collection of random bytes.

The test specification is updated to exercise the new feature. I attempted to run the tests with adobe@10.0.21+300068 to verify the project's claim of compatibility with that obsolete CFML engine. I'd wager that JWTService itself is still compatible.

I updated the test specification to use the new algorithm names and generated new tokens.