### PR TITLE
Add Git URL

### DIFF
--- a/box.json
+++ b/box.json
@@ -5,6 +5,10 @@
     "private":false,
     "type":"modules",
     "location":"andrew-dixon/cb-jwt#v1.0.1",
+    "repository":{
+        "type":"git",
+        "URL":"https://github.com/andrew-dixon/cb-jwt"
+    },
     "devDependencies":{
         "testbox":"2.3.0+00044"
     },


### PR DESCRIPTION
Your next `publish` will automatically add the link to your Github repo from the ForgeBox package description.