### PR TITLE
Using incorrect tag in location that doesn't match version

### DIFF
--- a/box.json
+++ b/box.json
@@ -4,7 +4,7 @@
     "slug":"jwt",
     "private":false,
     "type":"modules",
-    "location":"andrew-dixon/cb-jwt#v1.0.1",
+    "location":"andrew-dixon/cb-jwt#v1.1.0",
     "repository":{
         "type":"git",
         "URL":"https://github.com/andrew-dixon/cb-jwt"


### PR DESCRIPTION
Please run
```publish```
after merging to update ForgeBox as it has the old location in its DB too.